### PR TITLE
[Refactor / Feat] User 테이블, Member 테이블로 수정 및 Work 테이블 추가

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,50 +12,91 @@ enum Role {
   caseManager
 }
 
-model User {
-  id           Int           @id @default(autoincrement())
-  name         String
-  userName     String
-  passwordHash String
-  phone        String
-  role         Role
-  createdAt    DateTime      @default(now())
-  updatedAt    DateTime      @updatedAt
+enum SocialPlatform {
+  KAKAO
+  GOOGLE
+  NAVER
+}
+
+enum WorkEventType {
+  CLOCK_IN    // 출근
+  CLOCK_OUT   // 퇴근
+  // 추후 확장 가능
+  // OUTSIDE     // 외출
+  // RETURN      // 복귀
+}
+
+model Member {
+  id          Int            @id @default(autoincrement())
+  email       String
+  name        String
+  password    String
+  role        Role
+  createdAt   DateTime       @default(now())
+  updatedAt   DateTime       @updatedAt
+  deletedAt   DateTime?
 
   // Relations
-  clients            Client[]       @relation("CareWorkerClients")
-  careWorkerJournals Journal[]      @relation("CareWorkerJournals")
-  notifications      Notification[]
-  careWorkerInfo     CareWorker?    @relation("CareWorkerUser")
-  managedCareWorkers CareWorker[]   @relation("CaseManagerCareWorkers")
-  workShifts         WorkShift[]    @relation("CareWorkerWorkShifts")
+  socialAccounts    SocialAccount[]
+  managedCareWorkers ManageMember[]  @relation("CaseManagerToCareWorkers")
+  managedByCaseManager ManageMember[]  @relation("CareWorkerToCaseManager")
+  works             Work[]
+  journals          Journal[]       @relation("CareWorkerJournals")
+  notifications     Notification[]
   reportsAsCaseManager Report[]     @relation("Reports_CaseManager")
   reportsAsCareWorker  Report[]     @relation("Reports_CareWorker")
 }
 
-model Client {
-  id              Int        @id @default(autoincrement())
-  name            String
-  birthDate       DateTime
-  gender          String
-  address         String?
-  contact         String?
-  guardianContact String?
-  careWorkerId    Int
-  notes           String?
-  createdAt       DateTime   @default(now())
-  updatedAt       DateTime   @updatedAt
+model ManageMember {
+  id            Int     @id                // Member.id (role: careWorker)
+  caseManagerId Int
+  careWorker    Member  @relation("CareWorkerToCaseManager", fields: [id], references: [id])
+  caseManager   Member  @relation("CaseManagerToCareWorkers", fields: [caseManagerId], references: [id])
+}
+
+model SocialAccount {
+  id            Int           @id @default(autoincrement())
+  memberId      Int
+  platform      SocialPlatform
+  platformId    String        // 플랫폼에서 제공하는 고유 ID
+  createdAt     DateTime      @default(now())
 
   // Relations
-  careWorker      User       @relation("CareWorkerClients", fields: [careWorkerId], references: [id])
-  journals        Journal[]
-  reports         Report[]
-  workShifts      WorkShift[]
+  member        Member        @relation(fields: [memberId], references: [id])
+
+  @@unique([platform, platformId])
+}
+
+model Work {
+  id          Int       @id @default(autoincrement())
+  memberId    Int
+  date        DateTime
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  // Relations
+  member      Member    @relation(fields: [memberId], references: [id])
+  events      WorkEvent[]
+
+  @@unique([memberId, date])
+}
+
+model WorkEvent {
+  id          Int           @id @default(autoincrement())
+  workId      Int
+  type        WorkEventType
+  time        DateTime
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime      @updatedAt
+
+  // Relations
+  work        Work          @relation(fields: [workId], references: [id])
+
+  @@index([workId])
 }
 
 model Journal {
   id              Int       @id @default(autoincrement())
-  clientId        Int
   careWorkerId    Int
   rawAudioUrl     String
   transcript      String
@@ -71,8 +112,7 @@ model Journal {
   updatedAt       DateTime  @updatedAt
 
   // Relations
-  client          Client    @relation(fields: [clientId], references: [id])
-  careWorker      User      @relation("CareWorkerJournals", fields: [careWorkerId], references: [id])
+  careWorker      Member    @relation("CareWorkerJournals", fields: [careWorkerId], references: [id])
 }
 
 model Report {
@@ -80,7 +120,6 @@ model Report {
   caseManagerId Int
   periodStart   DateTime
   periodEnd     DateTime
-  clientId      Int
   careWorkerId  Int
   content       String
   exported      String?
@@ -88,39 +127,17 @@ model Report {
   updatedAt     DateTime @updatedAt
 
   // Relations
-  caseManager   User     @relation("Reports_CaseManager", fields: [caseManagerId], references: [id])
-  client        Client   @relation(fields: [clientId], references: [id])
-  careWorker    User     @relation("Reports_CareWorker", fields: [careWorkerId], references: [id])
-}
-
-model CareWorker {
-  id            Int     @id                // User.id (role: careWorker)
-  caseManagerId Int
-  user          User    @relation("CareWorkerUser", fields: [id], references: [id])
-  caseManager   User    @relation("CaseManagerCareWorkers", fields: [caseManagerId], references: [id])
-}
-
-model WorkShift {
-  id           Int       @id @default(autoincrement())
-  careWorkerId Int
-  clientId     Int
-  startTime    DateTime
-  endTime      DateTime?
-  createdAt    DateTime  @default(now())
-  updatedAt    DateTime  @updatedAt
-
-  // Relations
-  careWorker   User      @relation("CareWorkerWorkShifts", fields: [careWorkerId], references: [id])
-  client       Client    @relation(fields: [clientId], references: [id])
+  caseManager   Member   @relation("Reports_CaseManager", fields: [caseManagerId], references: [id])
+  careWorker    Member   @relation("Reports_CareWorker", fields: [careWorkerId], references: [id])
 }
 
 model Notification {
   id        Int      @id @default(autoincrement())
-  userId    Int
+  memberId  Int
   title     String
   content   String?
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  user      User     @relation(fields: [userId], references: [id])
+  member    Member   @relation(fields: [memberId], references: [id])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,7 +9,7 @@ datasource db {
 
 enum Role {
   careWorker
-  caseManager
+  socialWorker
 }
 
 enum SocialPlatform {
@@ -38,20 +38,21 @@ model Member {
 
   // Relations
   socialAccounts    SocialAccount[]
-  managedCareWorkers ManageMember[]  @relation("CaseManagerToCareWorkers")
-  managedByCaseManager ManageMember[]  @relation("CareWorkerToCaseManager")
+  managedCareWorkers ManageMember[]  @relation("SocialWorkerToCareWorkers")
+  managedBySocialWorker ManageMember[]  @relation("CareWorkerToSocialWorker")
   works             Work[]
   journals          Journal[]       @relation("CareWorkerJournals")
   notifications     Notification[]
-  reportsAsCaseManager Report[]     @relation("Reports_CaseManager")
+  reportsAsCSocialWorker Report[]     @relation("Reports_SocialWorker")
   reportsAsCareWorker  Report[]     @relation("Reports_CareWorker")
+  clients           Client[]        @relation("CareWorkerClients")
 }
 
 model ManageMember {
   id            Int     @id                // Member.id (role: careWorker)
-  caseManagerId Int
-  careWorker    Member  @relation("CareWorkerToCaseManager", fields: [id], references: [id])
-  caseManager   Member  @relation("CaseManagerToCareWorkers", fields: [caseManagerId], references: [id])
+  socialWorkerId Int
+  careWorker    Member  @relation("CareWorkerToSocialWorker", fields: [id], references: [id])
+  socialWorker   Member  @relation("SocialWorkerToCareWorkers", fields: [socialWorkerId], references: [id])
 }
 
 model SocialAccount {
@@ -65,6 +66,26 @@ model SocialAccount {
   member        Member        @relation(fields: [memberId], references: [id])
 
   @@unique([platform, platformId])
+}
+
+model Client {
+  id              Int        @id @default(autoincrement())
+  name            String
+  birthDate       DateTime
+  gender          String
+  address         String?
+  contact         String?
+  guardianContact String?
+  careWorkerId    Int
+  notes           String?
+  createdAt       DateTime   @default(now())
+  updatedAt       DateTime   @updatedAt
+
+  // Relations
+  careWorker      Member       @relation("CareWorkerClients", fields: [careWorkerId], references: [id], onDelete: Cascade)
+  journals        Journal[]
+  reports         Report[]
+  workShifts      WorkShift[]
 }
 
 model Work {
@@ -117,7 +138,7 @@ model Journal {
 
 model Report {
   id            Int      @id @default(autoincrement())
-  caseManagerId Int
+  socialWorkerId Int
   periodStart   DateTime
   periodEnd     DateTime
   careWorkerId  Int
@@ -127,7 +148,7 @@ model Report {
   updatedAt     DateTime @updatedAt
 
   // Relations
-  caseManager   Member   @relation("Reports_CaseManager", fields: [caseManagerId], references: [id])
+  socialWorker   Member   @relation("Reports_SocialWorker", fields: [socialWorkerId], references: [id])
   careWorker    Member   @relation("Reports_CareWorker", fields: [careWorkerId], references: [id])
 }
 


### PR DESCRIPTION
## #️⃣ Issue Number

#8

## 📝 요약(Summary)

프리즈마 스키마 수정 및 추가

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

1) User 테이블 명칭 변경
User 테이블 명칭을 Member로 변경했습니다. 참고 바랍니다.
변경 이유는 psql에 user 라는 예약어가 있기 때문입니다. user 테이블 명칭 때문에 에러가 발생하는 레퍼런스 참고합니다.
https://bskyvision.com/entry/PostgreSQL-user-%ED%85%8C%EC%9D%B4%EB%B8%94-%EC%A1%B0%ED%9A%8C-%EB%B0%A9%EB%B2%95

https://velog.io/@wooruk/PSQL-user%ED%85%8C%EC%9D%B4%EB%B8%94-%EC%A1%B0%ED%9A%8C%EC%8B%9C-%EB%B0%9C%EC%83%9D%EB%AC%B8%EC%A0%9C

<img width="976" alt="image" src="https://github.com/user-attachments/assets/ceb20ff1-e12d-4d85-9e9f-20bcc4656e6d" />
https://postgresql.kr/docs/13/sql-keywords-appendix.html

2) 관리 주체와 대상 구분짓기
요양보호사(?), 요양사(?) 명칭이 조금 헷갈려서 To를 붙였습니다. 
관리 주체와 대상을 조금 명확히 구분할 필요가 있는데, 변수명 추천 바랍니다..

3) Workshif 테이블명 변경
WorkShift 를 검색했을 때, 24시간 교대 근무에 가까운 것 같아서 단순히 work 로 테이블 명 변경했습니다.
work는 psql의 예약어에 포함되어 있지 않습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
