### PR TITLE
[Fix] 일지 생성 수정, stt 부분 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ journal-*.docx
 
 # python 캐시 파일
 __pycache__/
+
+# python 임시 파일
+temp/
+

--- a/python/report/service.py
+++ b/python/report/service.py
@@ -6,6 +6,8 @@ import openai
 import os
 import uuid
 from dotenv import load_dotenv
+import json
+import time
 
 class JournalRequest(BaseModel):
     text: str
@@ -39,80 +41,83 @@ def create_report_app() -> FastAPI:
 
     @app.post("/")
     def generate_journal_docx(data: JournalRequest):
-        # 1. 상담내용 요약 GPT 호출
-        response = openai.ChatCompletion.create(
-            model="gpt-3.5-turbo",
-            messages=[
-              {
-                "role": "system",
-                "content": (
-                    f"당신은 복지기관에서 사용하는 상담 보고서 요약을 작성하는 역할입니다.\n\n"
-                    f"당신에게 제공된 상담 원문을 바탕으로 대상자인 **{data.client}님**의 상태를 자연스럽고 정확하게 요약하세요.\n\n"
-                    f"❗️다음 조건을 반드시 지켜주세요:\n"
-                    f"- 문장은 '{data.client}님은 ~하고 계십니다'와 같이 3인칭 존칭 시점으로 작성하세요.\n"
-                    f"- 첫 문장은 '네,', '안녕하세요' 등으로 시작하지 마세요. → ❌\n"
-                    f"- '~입니다.', '~있습니다.', '~어려워하고 계십니다.'와 같이 자연스럽고 진단적인 톤을 사용하세요.\n"
-                    f"- GPT형 멘트(예: 요약해 드리겠습니다)는 쓰지 마세요. → ❌\n"
-                    f"- 한 문단으로 작성하며, 항목 구분이나 줄바꿈 없이 매끄럽게 연결된 문장으로 서술하세요."
-                )
-              },
-            {
-                "role": "user",
-                "content": data.text
-            }
-          ]
+        start = time.time()
+        transcript = data.text
+        # 1. 상담내용(요약)만 기존 프롬프트로 생성
+        summary_prompt = (
+            f"당신은 복지기관에서 사용하는 상담 보고서 요약을 작성하는 역할입니다.\n\n"
+            f"당신에게 제공된 상담 원문을 바탕으로 대상자인 **{transcript}**의 상태를 자연스럽고 정확하게 요약하세요.\n\n"
+            f"❗️다음 조건을 반드시 지켜주세요:\n"
+            f"- 문장은 '대상자님은 ~하고 계십니다'와 같이 3인칭 존칭 시점으로 작성하세요.\n"
+            f"- 첫 문장은 '네,', '안녕하세요' 등으로 시작하지 마세요. → ❌\n"
+            f"- '~입니다.', '~있습니다.', '~어려워하고 계십니다.'와 같이 자연스럽고 진단적인 톤을 사용하세요.\n"
+            f"- GPT형 멘트(예: 요약해 드리겠습니다)는 쓰지 마세요. → ❌\n"
+            f"- 한 문단으로 작성하며, 항목 구분이나 줄바꿈 없이 매끄럽게 연결된 문장으로 서술하세요."
         )
-        gpt_result = response.choices[0].message.content
-
-        # 2. 조치사항 GPT 호출
-        action_response = openai.ChatCompletion.create(
-            model="gpt-3.5-turbo",
+        summary_response = openai.ChatCompletion.create(
+            model="gpt-4.1",
             messages=[
-                {
-                    "role": "system",
-                    "content": (
-                        f"당신은 복지기관 상담 보고서의 '조치사항'을 작성하는 역할입니다. "
-                        f"아래 상담 내용을 참고하여, 대상자에게 필요한 조치사항을 한 문장으로 작성하세요."
-                    )
-                },
-                {
-                    "role": "user",
-                    "content": gpt_result
-                }
+                {"role": "system", "content": summary_prompt},
+                {"role": "user", "content": transcript}
             ]
         )
-        gpt_action = action_response.choices[0].message.content
+        summary = summary_response.choices[0].message.content
 
-        # 3. 템플릿 채우기
+        # 2. 나머지 항목은 한 번에 JSON으로 생성
+        meta_prompt = (
+            "아래 상담 대화 원문을 바탕으로 상담일지의 모든 항목(상담일자, 서비스, 담당자, 상담유형, 상담방법, 상담시간, 상담제목, 구분, 대상자, 연락처, 조치사항, 상담자의견, 상담결과, 비고)을 아래 JSON 형식으로 만들어줘. "
+            "상담내용(요약)은 이미 따로 생성했으니 제외해도 돼. "
+            "각 항목은 대화에 정보가 없더라도 상담의 흐름과 맥락을 바탕으로 반드시 추정해서 한 문장 이상으로 작성해줘. "
+            "특히 상담결과, 조치사항, 상담자의견, 비고 등은 빈 문자열로 두지 말고, 대화에서 유추해서라도 반드시 채워줘. "
+            "상담일자, 서비스, 담당자 등 명확히 알 수 없는 항목은 '정보 없음'으로 채워줘.\n"
+            "{\n"
+            "  \"상담일자\": \"\",\n"
+            "  \"서비스\": \"\",\n"
+            "  \"담당자\": \"\",\n"
+            "  \"상담유형\": \"\",\n"
+            "  \"상담방법\": \"\",\n"
+            "  \"상담시간\": \"\",\n"
+            "  \"상담제목\": \"\",\n"
+            "  \"구분\": \"\",\n"
+            "  \"대상자\": \"\",\n"
+            "  \"연락처\": \"\",\n"
+            "  \"조치사항\": \"\",\n"
+            "  \"상담자의견\": \"\",\n"
+            "  \"상담결과\": \"\",\n"
+            "  \"비고\": \"\"\n"
+            "}\n"
+            "상담 대화:\n" + transcript
+        )
+        meta_response = openai.ChatCompletion.create(
+            model="gpt-4.1",
+            messages=[{"role": "system", "content": meta_prompt}]
+        )
+        meta_json = json.loads(meta_response.choices[0].message.content)
+
+        # 3. 상담내용(요약)만 summary로 대체
+        meta_json["상담내용"] = summary
+
+        # 4. 템플릿 렌더링
         tpl = DocxTemplate("상담일지양식.docx")
-        tpl.render({
-            "상담일자": data.date,
-            "서비스": data.service,
-            "담당자": data.manager,
-            "상담유형": data.type,
-            "상담방법": data.method,
-            "상담시간": data.time,
-            "상담제목": data.title,
-            "구분": data.category,
-            "대상자": data.client,
-            "연락처": data.contact,
-            "조치사항": gpt_action,
-            "상담내용": gpt_result,
-            "상담자의견": data.opinion,
-            "상담결과": data.result,
-            "비고": data.note
-        })
+        tpl.render(meta_json)
 
-        # 4. 저장
+        # 5. 저장
         filename = f"journal-{uuid.uuid4()}.docx"
         filepath = f"./generated/{filename}"
         os.makedirs("generated", exist_ok=True)
         tpl.save(filepath)
 
-        # 5. 응답
+        # 6. 응답
+        end = time.time()
+        print(f"문서 생성 처리 시간: {end - start:.2f}초")
         return {
             "file": filename,
-            "path": filepath
+            "path": filepath,
+            "summary": summary,
+            "recommendations": meta_json["조치사항"],
+            "opinion": meta_json["상담자의견"],
+            "result": meta_json["상담결과"],
+            "note": meta_json["비고"]
         }
 
     return app 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -4,6 +4,7 @@ openai
 docxtpl
 python-multipart
 python-dotenv
-transformers
+transformers==4.36.2
 torch
 ffmpeg-python
+pydub

--- a/python/stt/service.py
+++ b/python/stt/service.py
@@ -4,13 +4,27 @@ from starlette.responses import JSONResponse
 import tempfile
 import os
 import traceback
-from transformers import pipeline
+from transformers import pipeline, WhisperForConditionalGeneration, WhisperProcessor
+from pydub import AudioSegment  # 추가
+import time  # 처리 시간 측정용
+import glob  # 파일 삭제용
 
-# HuggingFace Whisper 파이프라인 로드 (한국어 특화 모델 사용)
-pipe = pipeline(    
-    "automatic-speech-recognition",    
-    model="SungBeom/whisper-small-ko",    
-    device=-1) # CUDA 사용시 0, CPU만 사용할 경우 -1
+model_id = "SungBeom/whisper-small-ko"
+model = WhisperForConditionalGeneration.from_pretrained(model_id)
+processor = WhisperProcessor.from_pretrained(model_id)
+
+# 최신 transformers가 아니더라도, config에 명시적으로 세팅
+if not hasattr(model.generation_config, "no_timestamps_token_id"):
+    model.generation_config.no_timestamps_token_id = processor.tokenizer.convert_tokens_to_ids("<|notimestamps|>")
+
+pipe = pipeline(
+    "automatic-speech-recognition",
+    model=model,
+    tokenizer=processor.tokenizer,
+    feature_extractor=processor.feature_extractor,
+    return_timestamps=False,
+    device=-1
+)
 
 def create_stt_app() -> FastAPI:
     app = FastAPI()
@@ -38,7 +52,7 @@ def create_stt_app() -> FastAPI:
     @app.post("/")
     async def transcribe_buffer(request: Request):
         temp_file = None
-
+        start_time = time.time()  # 처리 시간 측정 시작
         try:
             content = await request.body()
             content_size = len(content)
@@ -67,33 +81,53 @@ def create_stt_app() -> FastAPI:
             if not os.path.exists(temp_file) or os.path.getsize(temp_file) == 0:
                 raise Exception("유효한 오디오 파일이 생성되지 않았습니다.")
 
-            # Whisper로 음성 인식
+            # webm 오디오를 20초씩 분할하여 Whisper로 각각 처리
             try:
-                result = pipe(temp_file)
-                transcribed_text = result["text"].strip()
-
+                audio = AudioSegment.from_file(temp_file, format="webm")
+                chunk_length_ms = 20 * 1000  # 20초
+                chunks = [audio[i:i+chunk_length_ms] for i in range(0, len(audio), chunk_length_ms)]
+                transcripts = []
+                for idx, chunk in enumerate(chunks):
+                    chunk_path = os.path.join(temp_dir, f"chunk_{os.getpid()}_{id(content)}_{idx}.wav")
+                    chunk.export(chunk_path, format="wav")
+                    result = pipe(chunk_path, return_timestamps=False)
+                    transcripts.append(result["text"].strip())
+                    os.remove(chunk_path)
+                transcribed_text = " ".join(transcripts).strip()
                 if not transcribed_text:
                     raise Exception("음성 인식 결과가 비어있습니다.")
-
+                end_time = time.time()
+                print(f"STT 전체 처리 시간: {end_time - start_time:.2f}초")
                 return {"text": transcribed_text}
-
             except Exception as e:
                 traceback.print_exc()
                 raise Exception(f"Whisper 처리 중 오류가 발생했습니다: {str(e)}")
-
         except Exception as e:
             traceback.print_exc()
             return JSONResponse(
                 status_code=500,
                 content={"error": str(e)}
             )
-
         finally:
             # 임시 파일 삭제
             try:
                 if temp_file and os.path.exists(temp_file):
                     os.remove(temp_file)
+                temp_dir = os.path.dirname(temp_file) if temp_file else tempfile.gettempdir()
+                # chunk_*.wav 파일 모두 삭제
+                for chunk_file in glob.glob(os.path.join(temp_dir, "chunk_*.wav")):
+                    try:
+                        os.remove(chunk_file)
+                    except Exception:
+                        pass
+                # audio_*.webm 파일 모두 삭제
+                for webm_file in glob.glob(os.path.join(temp_dir, "audio_*.webm")):
+                    try:
+                        os.remove(webm_file)
+                    except Exception:
+                        pass
             except Exception:
                 traceback.print_exc()
+    # ffmpeg가 시스템에 설치되어 있어야 webm → wav 변환이 정상 동작합니다.
 
     return app 

--- a/src/journal/dto/generate-journal-docx-response.dto.ts
+++ b/src/journal/dto/generate-journal-docx-response.dto.ts
@@ -1,4 +1,9 @@
 export class GenerateJournalDocxResponseDto {
   file: string;
   path: string;
+  summary: string;           // 상담내용(요약)
+  recommendations: string;   // 조치사항
+  opinion: string;           // 상담자의견
+  result: string;            // 상담결과
+  note: string;              // 비고
 } 

--- a/src/journal/journal.service.ts
+++ b/src/journal/journal.service.ts
@@ -41,7 +41,7 @@ export class JournalService {
     private readonly s3Service: S3Service,
   ) {
     this.sttServerUrl = this.configService.get<string>('STT_SERVER_URL', 'http://localhost:5000/transcribe');
-    this.sttTimeout = this.configService.get<number>('STT_TIMEOUT', 30000);
+    this.sttTimeout = this.configService.get<number>('STT_TIMEOUT', 60000);
     this.logger.log(`Initialized with STT_SERVER_URL: ${this.sttServerUrl}, STT_TIMEOUT: ${this.sttTimeout}`);
   }
 
@@ -71,7 +71,7 @@ export class JournalService {
               headers: {
                 'Content-Type': 'audio/webm',
               },
-              timeout: this.sttTimeout,
+              timeout: 60000,
               maxContentLength: Infinity,
               maxBodyLength: Infinity,
             },
@@ -198,12 +198,19 @@ export class JournalService {
     const requestBody = mapJournalToRequest(journal);
 
     const { data } = await firstValueFrom(
-      this.httpService.post('http://127.0.0.1:5000/generate-journal-docx', requestBody)
+      this.httpService.post('http://127.0.0.1:5000/generate-journal-docx', requestBody, { timeout: 60000 })
     );
 
     const updated = await this.prisma.journal.update({
       where: { id: journal.id },
-      data: { exportedDocx: data.path },
+      data: {
+        exportedDocx: data.path,
+        summary: data.summary,
+        recommendations: data.recommendations,
+        opinion: data.opinion,
+        result: data.result,
+        note: data.note,
+      },
     });
 
     return { ...data, updated };


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
close #16 

## 📝 요약(Summary)

- STT(Whisper) 처리 시 webm 오디오를 20초씩 분할하여 순차적으로 STT 처리하도록 개선했습니다.
- pydub, ffmpeg를 활용해 webm → wav 변환 및 분할을 자동화했습니다.
- STT 처리 후 temp 폴더 내 임시 webm, wav 파일이 모두 자동 삭제되도록 처리했습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)



| **DB에 STT가 저장된 상태**           | **Swagger로 일지 생성 테스트**      | **DB에 일지 생성을 통해 데이터가 들어간 상태**      |**생성된 일지**            |
|-----------------------------|-----------------------------|-----------------------------|-----------------------------|
| <img src="https://github.com/user-attachments/assets/4801c179-d19e-4503-8de5-5203b2255303" width="480" />  | <img src="https://github.com/user-attachments/assets/4867e38b-2aa7-4cfa-bfca-c3de403d46e2" width="480" />  | <img src="https://github.com/user-attachments/assets/355a831d-d05b-4d0a-a572-e1300f8e6254" width="480" />  | <img src="https://github.com/user-attachments/assets/dbeea2aa-73b0-4e51-9563-c29a499b34b7" width="480" />  |

## 💬 공유사항 to 리뷰어

**STT 20초 분할 이유**
STT 테스트를 하면서 녹음하는 오디오 길이가 30초 이상인 경우, 
계속 STT 결과가 누락되며 서버 연결 에러가 발생하였습니다..!
그래서 오디오를 20초씩 분할하여 각 조각을 개별적으로 STT 처리하도록 수정했습니다!

현재 STT 동작 과정
1. **클라이언트에서 녹음한 오디오 파일이 webm 포맷**으로 서버에 전달됩니다.
2. **서버(Python FastAPI)에서 이 webm 파일을 임시로 저장**합니다.
3. **pydub 라이브러리**를 사용해서
   - webm 파일을 불러오고(AudioSegment.from_file(temp_file, format="webm"))
   - 20초씩 분할한 뒤,
   - **각 chunk를 wav 파일로 변환하여 저장**합니다.(chunk.export(chunk_path, format="wav"))
4. **Whisper STT 모델은 wav 파일을 입력으로 받아 음성 인식**을 수행합니다.

- ffmpeg 바이너리 설치가 필수이니, 배포 환경에서도 확인해주세용!
- journal 테이블의 issues 컬럼이 필요 없을 것 같아서 삭제할까 합니다!!

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
