### PR TITLE
Feat/34 노인 정보 수정

### DIFF
--- a/src/client/client.controller.ts
+++ b/src/client/client.controller.ts
@@ -8,6 +8,7 @@ import {
   Param,
   ParseIntPipe,
   Post,
+  Put,
   UseGuards,
 } from '@nestjs/common';
 import { ClientService } from './client.service';
@@ -26,6 +27,7 @@ import { JournalService } from '../journal/journal.service';
 import { JournalListItemDto } from '../journal/dto/journal-list-item.dto';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { CurrentUser } from 'src/auth/decorators/current-user.decorator';
+import { UpdateClientDto } from './dto/update-client.dto';
 
 @UseGuards(JwtAuthGuard)
 @ApiBearerAuth('JWT')
@@ -128,6 +130,40 @@ export class ClientController {
       clientId,
       socialWorkerId,
       careWorkerId,
+    });
+  }
+
+  @Put(':id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: '특정 노인 정보 수정',
+    description: '특정 노인의 정보를 수정합니다.',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: '해당 노인 정보 변경 성공',
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: '해당 노인은 존재하지 않습니다.',
+  })
+  @ApiResponse({
+    status: HttpStatus.UNAUTHORIZED,
+    description: '권한이 없습니다.',
+  })
+  async putClient(
+    @Param('id', ParseIntPipe) id: number,
+    @CurrentUser() user,
+    @Body() data: UpdateClientDto,
+  ) {
+    const socialWorkerId = user.role === 'socialWorker' ? user.id : undefined;
+    const careWorkerId = user.role === 'careWorker' ? user.id : undefined;
+
+    return this.clientService.updateClient({
+      id,
+      socialWorkerId,
+      careWorkerId,
+      data,
     });
   }
 }

--- a/src/client/client.controller.ts
+++ b/src/client/client.controller.ts
@@ -199,7 +199,7 @@ export class ClientController {
       throw new UnauthorizedException('복지사만 수정할 수 있습니다.');
     }
 
-    return this.clientService.updateClientByCareWorker({
+    return await this.clientService.updateClientByCareWorker({
       id,
       socialWorkerId: user.id,
       careWorkerId,

--- a/src/client/client.service.ts
+++ b/src/client/client.service.ts
@@ -194,9 +194,11 @@ export class ClientService {
   }) {
     await this.findClient({ id, socialWorkerId });
 
-    return await this.prisma.client.update({
+    await this.prisma.client.update({
       where: { id },
       data: { careWorkerId },
     });
+
+    return { success: true, message: '담당 요양보호사가 변경되었습니다.' };
   }
 }

--- a/src/client/client.service.ts
+++ b/src/client/client.service.ts
@@ -182,4 +182,21 @@ export class ClientService {
       data: { birthDate: parsedDate, ...otherData },
     });
   }
+
+  async updateClientByCareWorker({
+    id,
+    socialWorkerId,
+    careWorkerId,
+  }: {
+    id: number;
+    socialWorkerId: number;
+    careWorkerId: number;
+  }) {
+    await this.findClient({ id, socialWorkerId });
+
+    return await this.prisma.client.update({
+      where: { id },
+      data: { careWorkerId },
+    });
+  }
 }

--- a/src/client/client.service.ts
+++ b/src/client/client.service.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { CreateClientDto } from './dto/create-client.dto';
+import { UpdateClientDto } from './dto/update-client.dto';
 
 @Injectable()
 export class ClientService {
@@ -155,5 +156,30 @@ export class ClientService {
     }
 
     return client;
+  }
+
+  async updateClient({
+    id,
+    socialWorkerId,
+    careWorkerId,
+    data,
+  }: {
+    id: number;
+    socialWorkerId: number;
+    careWorkerId: number;
+    data: UpdateClientDto;
+  }) {
+    const { birthDate, ...otherData } = data;
+    await this.findClient({ id, careWorkerId, socialWorkerId });
+
+    let parsedDate;
+    if (birthDate) {
+      parsedDate = new Date(birthDate);
+    }
+
+    return await this.prisma.client.update({
+      where: { id },
+      data: { birthDate: parsedDate, ...otherData },
+    });
   }
 }

--- a/src/client/dto/create-client.dto.ts
+++ b/src/client/dto/create-client.dto.ts
@@ -2,7 +2,6 @@ import { ApiProperty } from '@nestjs/swagger';
 import {
   IsString,
   IsInt,
-  IsDate,
   IsNotEmpty,
   IsOptional,
   Matches,

--- a/src/client/dto/update-client.dto.ts
+++ b/src/client/dto/update-client.dto.ts
@@ -5,6 +5,7 @@ import {
   IsNotEmpty,
   IsOptional,
   Matches,
+  IsNumber,
 } from 'class-validator';
 
 export class UpdateClientDto {
@@ -42,4 +43,11 @@ export class UpdateClientDto {
   @IsString()
   @IsOptional()
   notes?: string;
+}
+
+export class UpdateClientByCareWorkerDto {
+  @ApiProperty()
+  @IsNumber()
+  @IsNotEmpty()
+  careWorkerId: number;
 }

--- a/src/client/dto/update-client.dto.ts
+++ b/src/client/dto/update-client.dto.ts
@@ -1,0 +1,45 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsString,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  Matches,
+} from 'class-validator';
+
+export class UpdateClientDto {
+  @ApiProperty({ required: false })
+  @IsString()
+  @IsOptional()
+  name?: string;
+
+  @ApiProperty({ example: '2025-05-29', required: false })
+  @Matches(/^\d{4}-\d{2}-\d{2}$/)
+  @IsOptional()
+  birthDate?: string;
+
+  @ApiProperty({ required: false })
+  @IsString()
+  @IsOptional()
+  planningTime?: string;
+
+  @ApiProperty({ required: false })
+  @IsString()
+  @IsOptional()
+  address?: string;
+
+  @ApiProperty({ required: false })
+  @IsString()
+  @IsOptional()
+  contact?: string;
+
+  @ApiProperty({ required: false })
+  @IsString()
+  @IsOptional()
+  guardianContact?: string;
+
+  @ApiProperty({ required: false })
+  @IsString()
+  @IsOptional()
+  notes?: string;
+}


### PR DESCRIPTION
## #️⃣ Issue Number
close #34 #35 

## 📝 요약(Summary)
특정 노인 정보 수정 API 구현
=> 성별과 담당요양사는 수정이 되지 않습니다.

담당 요양 보호사 변경 API 구현
=> 담당 복지사만 가능하게 권한 설정했습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)
| 설명   | 이미지 |
|--------|--------|
| 노인 정보 수정 api | ![image](https://github.com/user-attachments/assets/2fde0734-9009-41c7-beff-cb4239bbeaa7) |
| 담당 요양보호사 변경 api | ![image](https://github.com/user-attachments/assets/0138566e-487c-4af8-88b2-d6e8de6ddca8)|


## 💬 공유사항 to 리뷰어
노인 정보 수정은 담당 복지사, 담당 요양보호사 둘 다 가능하게 설정은 해두었는데 담당 복지사만 가능하게 해야 될까요?


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
